### PR TITLE
Use non-blocking result in case if found code style issues

### DIFF
--- a/src/Task/PhpCsAutoFixerV2.php
+++ b/src/Task/PhpCsAutoFixerV2.php
@@ -51,6 +51,8 @@ class PhpCsAutoFixerV2 extends PhpCsFixerV2
             }else {
                 $this->runOnChangedFiles($context, $arguments, $files);
             }
+
+            $result = TaskResult::createNonBlockingFailed($this, $result->getContext(), $result->getMessage());
         }
 
         return $result;


### PR DESCRIPTION
## Problem
In case if PHP-CS-Fixer finds code style issue, it becomes failed rejecting the commit. It is misleading as auto-fixing should automatically deal with it.

## Reason
We should return non-blocking failed result. It means that we show the result is bad - but nevertheless we found a way to automatically fix it and commit was approved.

## Solution
I've just correct that behavior: after the 2nd run (which is actually fixing, following the 1st run (which is just scanning)), we return non-blocking failed result with all the context and errors from the 1st run. I've checked locally - it does the job perfectly.