### PR TITLE
Auto-add changed files to the commit

### DIFF
--- a/src/Task/PhpCsAutoFixerV2.php
+++ b/src/Task/PhpCsAutoFixerV2.php
@@ -2,6 +2,8 @@
 
 namespace Wearejust\GrumPHPExtra\Task;
 
+use GrumPHP\Collection\FilesCollection;
+use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Runner\TaskResult;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\RunContext;
@@ -88,4 +90,18 @@ class PhpCsAutoFixerV2 extends PhpCsFixerV2
         return $arguments;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function runOnChangedFiles(
+        ContextInterface $context,
+        ProcessArgumentsCollection $arguments,
+        FilesCollection $files
+    ) {
+        $result = parent::runOnChangedFiles($context, $arguments, $files);
+        foreach ($files as $file) {
+            exec(sprintf('git add %s', $file->getRelativePathname()));
+        }
+        return $result;
+    }
 }


### PR DESCRIPTION
## Problem
I want auto-fixed files to be added to the commit.

## Reason
It is not handled at all: we just need to add the files at the right moment.

## Solution
Here is the proposed change, it works locally. I guess that is how it is intended to work: scan a commit, fix code styling as desired - and finally add these changes to the same commit.