### PR TITLE
Fix Readme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,5 +212,5 @@ Disable ANSI output.
 **no_interaction**
 *Default: `null`*
 
-##License
+## License
 This package is licensed under the MIT License.  		


### PR DESCRIPTION
I fixed the readme markdown syntax in the License part.